### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Architecture: all
 Depends: ${misc:Depends}
 Recommends: debian-archive-keyring, debootstrap, wget
 Suggests: diffoscope
+Multi-Arch: foreign
 Description: reproducible, snapshot-based Debian rootfs builder
  A set of scripts for building reproducible Debian rootfs tarballs based on
  snapshot.debian.org, especially for the purposes of Docker base images.


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/debuerreotype/9055cc7c-93ab-440d-8c6f-20fa71a52cfd.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/9055cc7c-93ab-440d-8c6f-20fa71a52cfd/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/9055cc7c-93ab-440d-8c6f-20fa71a52cfd/diffoscope)).
