### PR TITLE
Ship examples

### DIFF
--- a/debian/debuerreotype.install
+++ b/debian/debuerreotype.install
@@ -1,2 +1,3 @@
 VERSION usr/share/debuerreotype/
 scripts usr/share/debuerreotype/
+examples usr/share/debuerreotype/

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,1 @@
+package-does-not-install-examples [examples/]


### PR DESCRIPTION
Hello!

I'd like to use the "examples" scripts.  Is it a mere oversight that they are not shipped in this packaging?  If so, this trivial patch puts them in `/usr/share/debuerreotype/examples`, and silences the lintian warning about not shipping examples.

If this is intentional, I think it would be nice to explain how to properly access these useful scripts (or why that's a bad idea).

I did not opt to use examples, because they seem to me to be at least as useful as the scripts.  Again, this might come from a misunderstanding on my part of the purpose of this packaging, so please correct me if I'm wrong.  In that case, it may make more sense to rename this directory (in debuerreotype proper) from "examples" to something like "distributions" (?maybe?).